### PR TITLE
README - Add :test-paths to project.clj sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Alternatively you may add it to your `project.clj`.
 ```clojure
 (defproject sample
   :dependencies [[org.clojure/clojure "1.8.0"]]
+  :test-paths ["test"]
   :profiles {:dev {:plugins [[com.jakemccrary/lein-test-refresh "0.25.0"]]}})
 ```
 


### PR DESCRIPTION
```
By default, test-refresh looks for tests under the test directory. You can use the -d flag to specify a different directory.
```
This didn't seem to work.

`:test-paths` however did work though they are hidden in an issue.